### PR TITLE
Depend on fuse 2.8.5-2 or higher

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+debathena-pyhesiodfs (0.0.r167-0debathena12) unstable; urgency=low
+
+  * Depend on fuse 2.8.5-2 in preference to fuse-utils, which no longer
+    exists in saucy and above (Trac: #1411)
+
+ -- Jonathan Reed <jdreed@mit.edu>  Mon, 21 Oct 2013 09:54:00 -0400
+
 debathena-pyhesiodfs (0.0.r167-0debathena11) unstable; urgency=low
 
   * Understand and appropriately display ERR lockers (Trac: #1329)

--- a/debian/control
+++ b/debian/control
@@ -3,11 +3,11 @@ Section: debathena/net
 Priority: extra
 Maintainer: Debathena Project <debathena@mit.edu>
 Build-Depends: cdbs, debhelper, quilt, patchutils, config-package-dev, python-dev, python-support
-Standards-Version: 3.7.3
+Standards-Version: 3.9.3
 
 Package: debathena-pyhesiodfs
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${python:Depends}, python-fuse, python-hesiod (>= 0.2.10), debathena-afs-config, debathena-hesiod-config, adduser, fuse-utils, lsb-base (>= 3.0-6)
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${python:Depends}, python-fuse, python-hesiod (>= 0.2.10), debathena-afs-config, debathena-hesiod-config, adduser, fuse (>= 2.8.5-2~) | fuse-utils, lsb-base (>= 3.0-6)
 Provides: ${python:Provides}
 Conflicts: debathena-afuse-automounter, debathena-autofs-config
 Replaces: debathena-afuse-automounter, debathena-autofs-config


### PR DESCRIPTION
fuse-utils is transitional in precise and gone in saucy, so
depend on a new enough fuse in preference to fuse-utils (Trac: #1411)

Also, bump Standards-Version
