### PR TITLE
Patch postinst so that the package installs on Debian Jessie.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+debathena-pyhesiodfs (1.1-0debathena3) unstable; urgency=low
+
+  * debian/debathena-pyhesiodfs.postinst: Add user pyhesiodfs to group fuse
+    only if the local group exists. As of Debian Jessie, the group fuse is no
+    longer used. (Trac: #1523)
+
+ -- Lizhou Sha <slz@mit.edu>  Sat, 18 Apr 2015 15:31:05 -0400
+
 debathena-pyhesiodfs (1.1-0debathena2) unstable; urgency=low
 
   * Add git-buildpackage configuration

--- a/debian/debathena-pyhesiodfs.postinst
+++ b/debian/debathena-pyhesiodfs.postinst
@@ -25,8 +25,14 @@ set -e
 
 case "$1" in
     configure)
-        adduser pyhesiodfs fuse
-        
+	# Adding pyhesiodfs only if the local user group fuse exists.
+	# The group fuse no longer exists in jessie.
+	# If the group fuse is needed, it should have been added when the package
+	# fuse, a dependency, was configured, before this script is run.
+	if grep -q "^fuse:" /etc/group; then
+	    adduser pyhesiodfs fuse
+	fi
+
 	if hash invoke-rc.d 2>/dev/null; then
 	    # If /dev/fuse has group root, restart udev to work around
 	    # <https://bugs.launchpad.net/ubuntu/+source/fuse/+bug/293502>


### PR DESCRIPTION
- `debian/debathena-pyhesiodfs.postinst`: Add user pyhesiodfs to group fuse
  only if the local group exists. As of Debian Jessie, the group fuse is no
  longer used. ([Trac: #1523](https://athena10.mit.edu/trac/ticket/1523))

Signed-off-by: Lizhou Sha slz@mit.edu
