### PR TITLE
Provide a native systemd unit file

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+debathena-pyhesiodfs (1.1-0debathena4) unstable; urgency=low
+
+  * Add a systemd unit file, translated from the sysvinit script. (Trac: #962)
+  * Add Build-Depends on dh_systemd.
+  * Add a systemd tmpfile to create /mit on demand.
+
+ -- Lizhou Sha <slz@mit.edu>  Sat, 18 Jun 2016 00:46:17 -0400
+
 debathena-pyhesiodfs (1.1-0debathena3) unstable; urgency=low
 
   * debian/debathena-pyhesiodfs.postinst: Add user pyhesiodfs to group fuse

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: debathena-pyhesiodfs
 Section: debathena/net
 Priority: extra
 Maintainer: Debathena Project <debathena@mit.edu>
-Build-Depends: cdbs, debhelper, config-package-dev, python-support, python (>= 2.6~)
+Build-Depends: cdbs, debhelper, dh-systemd (>= 1.5) | cdbs (<< 0.4.122~), config-package-dev, python-support, python (>= 2.6~)
 Standards-Version: 3.9.3
 
 Package: debathena-pyhesiodfs

--- a/debian/debathena-pyhesiodfs.service
+++ b/debian/debathena-pyhesiodfs.service
@@ -1,0 +1,17 @@
+# Author: Lizhou Sha <slz@mit.edu>
+# This file is part of the debathena-pyhesiodfs package.
+
+[Unit]
+Description=Hesiod automounter for Athena lockers
+After=local-fs.target network.target systemd-tmpfiles-setup.service
+Before=remote-fs.target
+
+[Service]
+Type=simple
+Environment="pyhesiodfs_dir=/mit"
+OOMScoreAdjust=-1000
+User=pyhesiodfs
+ExecStart=/usr/bin/pyhesiodfs -f ${pyhesiodfs_dir} -o nonempty
+
+[Install]
+WantedBy=multi-user.target remote-fs.target

--- a/debian/debathena-pyhesiodfs.tmpfile
+++ b/debian/debathena-pyhesiodfs.tmpfile
@@ -1,0 +1,1 @@
+d /mit 0770 root pyhesiodfs


### PR DESCRIPTION
- Add a systemd unit file, translated from the sysvinit script.
  (Trac: #962)
- Add Build-Depends on dh_systemd.

Signed-off-by: Lizhou Sha slz@mit.edu
